### PR TITLE
Updates and BugFixes

### DIFF
--- a/lib/Util.js
+++ b/lib/Util.js
@@ -48,8 +48,22 @@ function size(obj) {
   * @param {STRING} url To Check 
 */ 
 function isValidURL(url){
-    return url.match(/^https?:\/\/(www\.)?youtube\.com\/((channel\/UC[\w-]{21}[AQgw])|(c\/|user\/)?[\w-]+|@[\w-]+)$/) != null
-}
+  /*
+    Updated this validation to support both the old youtube link system and the new one, also added support for when the user sends an id of the channel
+    this works the three ways, might not be the best approach but it works.
+  */
+    const regex = /^(?:https?:\/\/(www\.)?youtube\.com\/((channel\/UC[\w-]{21}[AQgw])|(c\/|user\/)?[\w-]+|@[\w-]+))$|^UC[\w-]{21}[AQgw]$/;
+    //Check if the url matches the format
+    if (regex.test(url)) {
+        //if the user inputs only the id, we add it to the url and return it after, otherwise we just return
+        if (!url.startsWith("http")) {
+            url = "https://www.youtube.com/channel/" + url;
+        }
+        return url;
+    }
+    //if it does not match, we return false wich should return the error message
+    return false;
+  }
 
 
 /** Sleep for some Time

--- a/lib/Util.js
+++ b/lib/Util.js
@@ -48,7 +48,7 @@ function size(obj) {
   * @param {STRING} url To Check 
 */ 
 function isValidURL(url){
-    return url.match(/^https?:\/\/(www\.)?youtube\.com\/(channel\/UC[\w-]{21}[AQgw]|(c\/|user\/)?[\w-]+)$/) != null
+    return url.match(/^https?:\/\/(www\.)?youtube\.com\/((channel\/UC[\w-]{21}[AQgw])|(c\/|user\/)?[\w-]+|@[\w-]+)$/) != null
 }
 
 

--- a/lib/YoutubePoster.js
+++ b/lib/YoutubePoster.js
@@ -34,6 +34,10 @@ const CI = require('./channelInfo.js')
 const JoshJSON = require('@joshdb/json'); //default Provider but there are also many other things like mongodb sqlite and more!
 //swap the provider: https://josh.evie.dev/providers/about
 
+
+//The new validation for the length of the guildID
+const discordSnowflakeRegex = /^(?:\d{17,20})$/;
+
 //MAKE SURE TO INSTALL THE GIVEN PROVIDER TOO!, @joshdb/json @joshdb/mongo are already installed but sqlite etc. not, this is to support REPLIT etc.
 class YoutubePoster {
     /**
@@ -318,7 +322,7 @@ class YoutubePoster {
         return new Promise(async (res, rej) => {
             try {
                 if (!DiscordGuildID) return rej("A String is required for the DiscordGuildID");
-                if (typeof DiscordGuildID !== "string") return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
+                if (typeof DiscordGuildID !== "string" || !discordSnowflakeRegex.test(DiscordGuildID)) return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
                 if (!ChannelLink) return rej("A String is required for the ChannelLink");
                 if (typeof ChannelLink !== "string") return rej(`Passed in ${typeof ChannelLink} but a String would be required for the ChannelLink`);
                 if (!Util.isValidURL(ChannelLink)) return rej(`${ChannelLink} is not a Valid URL (YT)`);
@@ -350,7 +354,7 @@ class YoutubePoster {
         return new Promise(async (res, rej) => {
             try {
                 if (!DiscordGuildID) return rej("A String is required for the DiscordGuildID");
-                if (typeof DiscordGuildID !== "string") return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
+                if (typeof DiscordGuildID !== "string" || !discordSnowflakeRegex.test(DiscordGuildID)) return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
                 if (!DiscordUser || !DiscordUser.id) return rej("No User with a Valid ID added for DiscordUser");
                 await this.YTP_DB.ensure(DiscordGuildID, {
                     channels: []
@@ -433,7 +437,7 @@ class YoutubePoster {
                 if (!ChannelLink) return rej("A String is required for the ChannelLink");
                 if (typeof ChannelLink !== "string") return rej(`Passed in ${typeof ChannelLink} but a String would be required for the ChannelLink`);
                 if (!DiscordGuildID) return rej("A String is required for the DiscordGuildID");
-                if (typeof DiscordGuildID !== "string") return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
+                if (typeof DiscordGuildID !== "string" || !discordSnowflakeRegex.test(DiscordGuildID)) return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
                 if (!Util.isValidURL(ChannelLink)) return rej(`${ChannelLink} is not a Valid URL (YT)`);
                 await this.YTP_DB.ensure(DiscordGuildID, {
                     channels: []
@@ -470,7 +474,7 @@ class YoutubePoster {
         return new Promise(async (res, rej) => {
             try {
                 if (!DiscordGuildID) return rej("A String is required for the DiscordGuildID");
-                if (typeof DiscordGuildID !== "string") return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
+                if (typeof DiscordGuildID !== "string" || !discordSnowflakeRegex.test(DiscordGuildID)) return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
                 await this.YTP_DB.ensure(DiscordGuildID, {
                     channels: []
                 });
@@ -492,7 +496,7 @@ class YoutubePoster {
         return new Promise(async (res, rej) => {
             try {
                 if (!DiscordGuildID) return rej("A String is required for the DiscordGuildID");
-                if (typeof DiscordGuildID !== "string") return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
+                if (typeof DiscordGuildID !== "string" || !discordSnowflakeRegex.test(DiscordGuildID)) return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
                 let olddata = await this.YTP_DB.get(`${DiscordGuildID}.channels`);
                 await this.YTP_DB.set(DiscordGuildID, {
                     channels: []

--- a/lib/YoutubePoster.js
+++ b/lib/YoutubePoster.js
@@ -318,7 +318,7 @@ class YoutubePoster {
         return new Promise(async (res, rej) => {
             try {
                 if (!DiscordGuildID) return rej("A String is required for the DiscordGuildID");
-                if (typeof DiscordGuildID !== "string" || DiscordGuildID.length != 18) return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
+                if (typeof DiscordGuildID !== "string") return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
                 if (!ChannelLink) return rej("A String is required for the ChannelLink");
                 if (typeof ChannelLink !== "string") return rej(`Passed in ${typeof ChannelLink} but a String would be required for the ChannelLink`);
                 if (!Util.isValidURL(ChannelLink)) return rej(`${ChannelLink} is not a Valid URL (YT)`);
@@ -350,7 +350,7 @@ class YoutubePoster {
         return new Promise(async (res, rej) => {
             try {
                 if (!DiscordGuildID) return rej("A String is required for the DiscordGuildID");
-                if (typeof DiscordGuildID !== "string" || DiscordGuildID.length != 18) return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
+                if (typeof DiscordGuildID !== "string") return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
                 if (!DiscordUser || !DiscordUser.id) return rej("No User with a Valid ID added for DiscordUser");
                 await this.YTP_DB.ensure(DiscordGuildID, {
                     channels: []
@@ -433,7 +433,7 @@ class YoutubePoster {
                 if (!ChannelLink) return rej("A String is required for the ChannelLink");
                 if (typeof ChannelLink !== "string") return rej(`Passed in ${typeof ChannelLink} but a String would be required for the ChannelLink`);
                 if (!DiscordGuildID) return rej("A String is required for the DiscordGuildID");
-                if (typeof DiscordGuildID !== "string" || DiscordGuildID.length != 18) return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
+                if (typeof DiscordGuildID !== "string") return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
                 if (!Util.isValidURL(ChannelLink)) return rej(`${ChannelLink} is not a Valid URL (YT)`);
                 await this.YTP_DB.ensure(DiscordGuildID, {
                     channels: []
@@ -470,7 +470,7 @@ class YoutubePoster {
         return new Promise(async (res, rej) => {
             try {
                 if (!DiscordGuildID) return rej("A String is required for the DiscordGuildID");
-                if (typeof DiscordGuildID !== "string" || DiscordGuildID.length != 18) return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
+                if (typeof DiscordGuildID !== "string") return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
                 await this.YTP_DB.ensure(DiscordGuildID, {
                     channels: []
                 });
@@ -492,7 +492,7 @@ class YoutubePoster {
         return new Promise(async (res, rej) => {
             try {
                 if (!DiscordGuildID) return rej("A String is required for the DiscordGuildID");
-                if (typeof DiscordGuildID !== "string" || DiscordGuildID.length != 18) return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
+                if (typeof DiscordGuildID !== "string") return rej(`Passed in ${typeof DiscordGuildID} but a String would be required for the DiscordGuildID`);
                 let olddata = await this.YTP_DB.get(`${DiscordGuildID}.channels`);
                 await this.YTP_DB.set(DiscordGuildID, {
                     channels: []


### PR DESCRIPTION
1. Changed the valid url to support the new YouTube username format
(https://www.youtube.com/@USERNAME)

2. Removed DiscordGuildID.length != 18 validation since it's causing the following error
Passed in string but a String would be required for the DiscordGuildID

![err](https://github.com/Tomato6966/discord-yt-poster/assets/65349887/7743032d-91f9-4433-99bd-b88f5b17c77b)

-------- EDIT (14/08/2023 UTC -5) --------
1. Added the regex validation to the length of the guild ID (since the size of the guild ID may increase in the future, this might need some updates)

2. Updated the "isValidURL()" function to now support the old YouTube channel links (with its ID on it) the new one (@USERNAME) or if the user sends the ID (the ID will be added to a link then returned as if it was sent as a full link from the beginning)

